### PR TITLE
Update npy_append_array.py

### DIFF
--- a/npy_append_array/npy_append_array.py
+++ b/npy_append_array/npy_append_array.py
@@ -139,7 +139,9 @@ class NpyAppendArray:
 
     def append(self, arr):
         if not arr.flags.c_contiguous:
-            raise NotImplementedError("ndarray needs to be c_contiguous")
+            arr = np.ascontiguousarray(arr)
+            if not arr.flags.c_contiguous:
+                raise NotImplementedError("ndarray needs to be c_contiguous")
 
         if self.__is_init is None:
             self.__init()

--- a/npy_append_array/npy_append_array.py
+++ b/npy_append_array/npy_append_array.py
@@ -2,6 +2,7 @@ import numpy as np
 import os.path
 from io import BytesIO, SEEK_END, SEEK_SET
 
+
 class NpyAppendArray:
     """
     appends/writes numpy arrays to file.
@@ -27,9 +28,9 @@ class NpyAppendArray:
         if os.path.isfile(self.filename):
             with open(self.filename, mode="rb+") as fp:
                 magic = np.lib.format.read_magic(fp)
-        if magic != (2, 0):
-            arr = np.load(self.filename)
-            self.write(arr)
+            if magic != (2, 0):
+                arr = np.load(self.filename)
+                self.write(arr)
 
     def __create_header_bytes(self, spare_space = True):
         from struct import pack

--- a/npy_append_array/npy_append_array.py
+++ b/npy_append_array/npy_append_array.py
@@ -52,16 +52,8 @@ class NpyAppendArray:
 
         return io.getbuffer()
 
-    def __init(self):
-        try: 
-            return self.__init_from_existing()
-        except NotImplementedError:
-            ## we load and re-save the file, this time using NPA and extended headers to allow appending
-            arr = np.load(self.filename)
-            self.write(arr)
-            return self.__init_from_existing()
         
-    def __init_from_existing(self):
+    def __init(self):
         if not os.path.isfile(self.filename):
             self.__is_init = False
             return


### PR DESCRIPTION
- support for both write/append for a smooth switching between the two
- I did this by splitting the self.write() from the __init() code
- if original file did not support appending, we will try in the background to re-save it so it does. 
- if original array is not contiguous, we will try in the background to make it contiguous
